### PR TITLE
Fix Dockerfile to reduce images size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM rhikimochi/opencv-docker:v0.14
+FROM rhikimochi/opencv-docker:v0.14 as builder
 
-COPY . /run
-WORKDIR /run
+COPY . /app
+WORKDIR /app
 RUN mkdir build && \
     cd build && \
     cmake .. && \
     make
-RUN mv bin/gazosan /usr/local/bin
-RUN rm -r /run/*
+
+FROM ubuntu:rolling
+WORKDIR /app
+COPY --from=builder /app/bin/gazosan /usr/local/bin
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /lib/x86_64-linux-gnu/libjpeg.so.8 \
+     /lib/x86_64-linux-gnu/libpng16.so.16 \
+     /lib/x86_64-linux-gnu/libtiff.so.5 \
+     /lib/x86_64-linux-gnu/libtbb.so.2 \
+     /lib/x86_64-linux-gnu/libwebp.so.6 \
+     /lib/x86_64-linux-gnu/libjbig.so.0 \
+     /lib/x86_64-linux-gnu/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker run --rm -it -v `pwd`:/run lifullsetg/gazo-san gazosan tests/images/test_
 
 ### With option --create-change-image
 ```
-docker run --rm -it -v `pwd`:/run lifullsetg/gazo-san gazosan tests/images/test_image_new.png tests/images/test_image_old.png output --create-change-image
+docker run --rm -it -v `pwd`:/app lifullsetg/gazo-san gazosan tests/images/test_image_new.png tests/images/test_image_old.png output --create-change-image
 ```
 
 | Output | Output |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd Gazo-san
 
 Execute Gazo-san by container
 ```
-docker run --rm -it -v `pwd`:/run lifullsetg/gazo-san gazosan tests/images/test_image_new.png tests/images/test_image_old.png output
+docker run --rm -it -v `pwd`:/app lifullsetg/gazo-san gazosan tests/images/test_image_new.png tests/images/test_image_old.png output
 ```
 
 | Input | Input |

--- a/src/imageDiffCalc.cpp
+++ b/src/imageDiffCalc.cpp
@@ -71,7 +71,7 @@ bool g_bCreateChangeImg = false;
 
 
 ////////// Global function //////////
-int ImgSegMain(int argc, char* argv[]);
+int ImgSegMain(int argc, const char** argv);
 int ImgSeg00(const std::string& strOldImgFile, const std::string& strNewImgFile);
 void ImgSeg01(const std::string& strImgFile, const std::string& strOutputFolder);
 void ImgSeg02(const std::string& strOldFile, const std::vector<std::string>& strOldPartFileList, const std::string& strNewFile, const std::vector<std::string>& strNewPartFileList, const std::string& strOutputFolder);
@@ -119,7 +119,7 @@ inline void SetProcessErrorMsg(const int& nStepNo)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-int ImgSegMain(int argc, char* argv[])
+int ImgSegMain(int argc, const char** argv)
 {
 	std::clog.setstate(std::ios_base::failbit);
 	std::string strOldFile, strNewFile;

--- a/src/imageDiffCalc.cpp
+++ b/src/imageDiffCalc.cpp
@@ -182,7 +182,7 @@ int ImgSegMain(int argc, const char** argv)
 	//ImgSeg01
 	{
 		// create new folder under temporary folder, and parts division
-		std::string strOutputFolder = "./image_diff_temp/new/";
+		std::string strOutputFolder = "/tmp/image_diff_temp/new/";
 		CreateDirectory(strOutputFolder);
 		g_nPartFileNo = 1;
 		ImgSeg01(strNewFile, strOutputFolder);
@@ -190,7 +190,7 @@ int ImgSegMain(int argc, const char** argv)
 		g_strFileList.clear();
 
 		// create old folder under temporary folder, and parts division
-		strOutputFolder = "./image_diff_temp/old/";
+		strOutputFolder = "/tmp/image_diff_temp/old/";
 		CreateDirectory(strOutputFolder);
 		g_nPartFileNo = 1;
 		ImgSeg01(strOldFile, strOutputFolder);
@@ -208,7 +208,7 @@ int ImgSegMain(int argc, const char** argv)
 	{
 		std::string strOutputFolder = "./";
 		ImgSeg03(strOldFile, g_strFileDiffInfoListMap, strOutputFolder);
-		if (system("exec rm -r ./image_diff_temp") != 0)
+		if (system("exec rm -r /tmp/image_diff_temp") != 0)
 		{
 			std::cerr << "Fail in delete temp directoty." << std::endl;
 			return -1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 
-int ImgSegMain(int argc, char* argv[]);
+int ImgSegMain(int argc, const char** argv);
 bool GetTimeHHMMSS(tm* pTM, std::string& strHHMMSS);
 
-int main(int argc, char* argv[])
+int main(int argc, const char** argv)
 {
 	std::string strHHMMSS_Start;
 	GetTimeHHMMSS(NULL, strHHMMSS_Start);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,13 +8,15 @@ int main(int argc, const char** argv)
 	std::string strHHMMSS_Start;
 	GetTimeHHMMSS(NULL, strHHMMSS_Start);
 
+	std::cout << "Start detection" << std::endl;
+
 	//ImgSeg
 	ImgSegMain(argc, argv);
 
 	std::string strHHMMSS_End;
 	GetTimeHHMMSS(NULL, strHHMMSS_End);
 
-	std::clog << "Process time : " << strHHMMSS_Start << " - " << strHHMMSS_End << std::endl;
+	std::cout << "Process time : " << strHHMMSS_Start << " - " << strHHMMSS_End << std::endl;
 
 	return 0;
 }

--- a/tests/system_tests/imageDiffCalc_test.cpp
+++ b/tests/system_tests/imageDiffCalc_test.cpp
@@ -101,7 +101,7 @@ protected:
 TEST_F(ImgSegMainTest, GeneralExec) {
     std::string want = "./image_difference_diff.png";
     int argc = 3;
-    char* argv[] = {(char*)"./test", (char*)"tests/images/test_image_new.png", (char*)"tests/images/test_image_old.png"};
+    const char* argv[] = {(char*)"./test", (char*)"tests/images/test_image_new.png", (char*)"tests/images/test_image_old.png"};
     ImgSegMain(argc, argv);
     bool isExists = FileExists(want);
     ASSERT_TRUE(isExists);
@@ -109,7 +109,7 @@ TEST_F(ImgSegMainTest, GeneralExec) {
 
 TEST_F(ImgSegMainTest, NotEnoughArgs) {
     int argc = 2;
-    char* argv[] = {(char*)"./test", (char*)"Not Enough"};
+    const char* argv[] = {(char*)"./test", (char*)"Not Enough"};
     std::string want;
     want.append("Not enough input\n ");
     want.append("-> 1st : Relative path for new color image file\n ");
@@ -123,7 +123,7 @@ TEST_F(ImgSegMainTest, NotEnoughArgs) {
 
 TEST_F(ImgSegMainTest, HelpOption) {
     int argc = 2;
-    char* argv[] = {(char*)"./test", (char*)"--help"};
+    const char* argv[] = {(char*)"./test", (char*)"--help"};
     std::string want;
     want.append("\nUsage:\n  options [OPTION...] positional parameters\n\n  ");
     want.append("-v, --verbose              Enable verbose output message\n  ");
@@ -141,7 +141,7 @@ TEST_F(ImgSegMainTest, HelpOption) {
 
 TEST_F(ImgSegMainTest, VerboseOption) {
     int argc = 4;
-    char* argv[] = {(char*)"./test", (char*)"tests/images/test_image_new.png", (char*)"tests/images/test_image_old.png", (char*)"-v"};
+    const char* argv[] = {(char*)"./test", (char*)"tests/images/test_image_new.png", (char*)"tests/images/test_image_old.png", (char*)"-v"};
     StartRecordClog();
     ImgSegMain(argc, argv);
     std::string got = GetRecordClog();
@@ -151,7 +151,7 @@ TEST_F(ImgSegMainTest, VerboseOption) {
 TEST_F(ImgSegMainTest, CreateChangeImageOption) {
     std::string want = "image_difference_add.png\nimage_difference_delete.png\n";
     int argc = 4;
-    char* argv[] = {(char*)"./test", (char*)"tests/images/test_image_new.png", (char*)"tests/images/test_image_old.png", (char*)"--create-change-image"};
+    const char* argv[] = {(char*)"./test", (char*)"tests/images/test_image_new.png", (char*)"tests/images/test_image_old.png", (char*)"--create-change-image"};
     ImgSegMain(argc, argv);
     std::string got = FindChangeImage();
     ASSERT_EQ(want, got);


### PR DESCRIPTION
1. Change dockerfile to multiple stage build. 
Remove the unused library and the size change 1.6GB -> 171MB

2. Change argv to const, due to the change of cxxopts
(https://github.com/jarro2783/cxxopts/issues/252)

3. Add output message when starting and ending the execution.

4. Fix the test script